### PR TITLE
Fix: Update command argument format in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,8 +52,7 @@ def run_simulation():
                     cmd.append(f"--{key}")
             # Handle other arguments with values
             elif value is not None and value != '': # Add argument if it has a value
-                cmd.append(f"--{key}")
-                cmd.append(str(value)) # Ensure value is a string for the command line
+                cmd.append(f"--{key}={value}") # Combine key and value
 
         logging.info(f"Constructed command: {' '.join(cmd)}") # Log the command for debugging
 


### PR DESCRIPTION
Changes the construction of command-line arguments for the simulation script. Previously, arguments were formatted as `--key value`. This commit updates the formatting to `--key=value` as required.