### PR TITLE
Refactor: Parameterize living cost and salary growth rates

### DIFF
--- a/financial_life/simulate_funs.py
+++ b/financial_life/simulate_funs.py
@@ -89,12 +89,16 @@ def simulate_a_life(args):
     # --- Setup Simulation Entities ---
     try:
         filipe = Human(starting_cash=args.starting_cash,
-                       living_costs=generate_living_costs(),
+                       living_costs=generate_living_costs(rate_pre_retirement=args.living_costs_rate_pre_retirement,
+                                                          rate_post_retirement=args.living_costs_rate_post_retirement,
+                                                          retirement_year=args.retirement_year,
+                                                          final_year=args.final_year),
                        non_linear_utility=args.non_linear_utility,
                        pension_draw_down_function=linear_pension_draw_down_function)
         log_debug_event(debug_data, args.start_year -1, "Init", "Start Cash", args.starting_cash)
 
-        my_employment = Employment(gross_salary=generate_salary(),
+        my_employment = Employment(gross_salary=generate_salary(growth_rate=args.salary_growth_rate,
+                                                                last_work_year=args.retirement_year - 1),
                                    employee_pension_contributions_pct=args.employee_pension_contributions_pct,
                                    employer_pension_contributions_pct=args.employer_pension_contributions_pct)
 

--- a/financial_life/simulate_main.py
+++ b/financial_life/simulate_main.py
@@ -51,6 +51,9 @@ def main():
     parser.add_argument("--pension_growth_rate", type=float, default=0.02, help="Annual growth rate for pension investments.")
     parser.add_argument("--ISA_growth_rate", type=float, default=0.02, help="Annual growth rate for ISA investments.")
     parser.add_argument("--GIA_growth_rate", type=float, default=0.02, help="Annual growth rate for GIA investments.")
+    parser.add_argument("--living_costs_rate_pre_retirement", type=float, default=0.02, help="Annual living costs growth rate before retirement (e.g., 0.02 for 2%).")
+    parser.add_argument("--living_costs_rate_post_retirement", type=float, default=0.04, help="Annual living costs growth rate after retirement (e.g., 0.04 for 4%).")
+    parser.add_argument("--salary_growth_rate", type=float, default=0.01, help="Annual gross salary growth rate (e.g., 0.01 for 1%).")
 
     # --- Employment Arguments ---
     parser.add_argument("--employee_pension_contributions_pct", type=float, default=0.07, help="Employee pension contribution as a percentage of gross salary (e.g., 0.07 for 7%).")


### PR DESCRIPTION
Made the following rates configurable via command-line arguments instead of being hardcoded:
- Living costs growth rate before retirement (`--living_costs_rate_pre_retirement`)
- Living costs growth rate after retirement (`--living_costs_rate_post_retirement`)
- Salary growth rate (`--salary_growth_rate`)

Changes include:
- Modified `generate_living_costs` and `generate_salary` in `human.py` to accept rate and relevant year parameters.
- Updated the calls to these functions in `simulate_a_life` (`simulate_funs.py`) to pass the new arguments from the `args` object.
- Added the corresponding command-line arguments with defaults to `main` in `simulate_main.py` using argparse.

This allows for greater flexibility in running simulations with different economic assumptions.