### PR TITLE
Add streamlit to requirements

### DIFF
--- a/financial_life/requirements.txt
+++ b/financial_life/requirements.txt
@@ -4,3 +4,4 @@ google-cloud-storage
 numpy
 numpy-financial
 google-cloud-aiplatform
+streamlit


### PR DESCRIPTION
The streamlit library is used by streamlit_app.py but was missing from the requirements.txt file. This commit adds it as a dependency.