### PR TITLE
Fix: Correct Streamlit port and address config in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,4 @@ EXPOSE 8501
 # ENV PYTHONPATH=/app
 
 # Run streamlit_app.py when the container launches
-# Use ${PORT:-8501} to allow Cloud Run to set the port, defaulting to 8501
-CMD ["streamlit", "run", "streamlit_app.py", "--server.port", "${PORT:-8501}", "--server.enableCORS", "false"]
+ENTRYPOINT ["streamlit", "run", "streamlit_app.py", "--server.port=8501", "--server.address=0.0.0.0"]


### PR DESCRIPTION
The previous Dockerfile used CMD and attempted to use an environment variable for the port, and did not explicitly set the server address. This prevented the Streamlit application from being accessible outside the container.

This commit updates the Dockerfile according to Streamlit's documentation for Docker deployments:
- Replaces CMD with ENTRYPOINT for running the Streamlit app.
- Sets the server port directly using --server.port=8501.
- Sets the server address to 0.0.0.0 using --server.address=0.0.0.0 to allow external access.
- Removes the unnecessary --server.enableCORS argument.