### PR TITLE
Fix: Configure Streamlit for Cloud Run deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,9 @@ RUN pip install --no-cache-dir --upgrade pip
 RUN pip install --no-cache-dir -r requirements.txt # Install simulation AND Streamlit dependencies (streamlit is in requirements.txt)
 
 # Make Streamlit's default port available
-EXPOSE 8501
 
 # Optional: Set PYTHONPATH if your simulation code uses relative imports across modules
 # ENV PYTHONPATH=/app
 
 # Run streamlit_app.py when the container launches
-ENTRYPOINT ["streamlit", "run", "streamlit_app.py", "--server.port=8501", "--server.address=0.0.0.0"]
+ENTRYPOINT ["streamlit", "run", "streamlit_app.py", "--server.port=$PORT", "--server.address=0.0.0.0"]


### PR DESCRIPTION
Modified the Dockerfile to correctly run the Streamlit application in a Cloud Run environment.

- Changed the ENTRYPOINT to use the $PORT environment variable instead of the hardcoded port 8501.
- Removed the unnecessary EXPOSE 8501 directive.

This ensures the application listens on the port specified by Cloud Run, resolving the startup probe failure.