### PR TITLE
Fix: Correct Dockerfile ENTRYPOINT for PORT variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,5 @@ RUN pip install --no-cache-dir -r requirements.txt # Install simulation AND Stre
 # ENV PYTHONPATH=/app
 
 # Run streamlit_app.py when the container launches
-ENTRYPOINT ["streamlit", "run", "streamlit_app.py", "--server.port=$PORT", "--server.address=0.0.0.0"]
+# Use shell form to allow $PORT substitution
+ENTRYPOINT streamlit run streamlit_app.py --server.port=$PORT --server.address=0.0.0.0


### PR DESCRIPTION
The previous ENTRYPOINT used the exec form with double quotes around the --server.port argument, preventing the $PORT environment variable from being substituted.

This commit changes the ENTRYPOINT to use the shell form, allowing the shell to correctly substitute the $PORT variable before executing the streamlit command.