### PR TITLE
Fix: Add app root to PYTHONPATH in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN pip install --no-cache-dir -r requirements.txt # Install simulation AND Stre
 # Make Streamlit's default port available
 
 # Optional: Set PYTHONPATH if your simulation code uses relative imports across modules
-# ENV PYTHONPATH=/app
+ENV PYTHONPATH=/app
 
 # Run streamlit_app.py when the container launches
 # Use shell form to allow $PORT substitution


### PR DESCRIPTION
Uncommented `ENV PYTHONPATH=/app` in the Dockerfile.

This ensures that the `financial_life` package, located in the application root directory, can be correctly imported by `streamlit_app.py` when running inside the container, resolving the 'Could not import simulation function' error.