### PR TITLE
Fix: Add repository root to sys.path in streamlit_app.py

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,8 +2,11 @@ import streamlit as st
 import argparse # Using argparse to create a Namespace object
 import logging
 import pandas as pd # Needed for displaying debug data
+import sys
 
 # --- Import Simulation Function ---
+# Add the repository root to the Python path
+sys.path.insert(0, '.')
 # Assuming the script is run from the repo root
 try:
     from financial_life.simulate_main import run_simulation_and_get_results


### PR DESCRIPTION
This resolves an ImportError where streamlit_app.py could not find the 'financial_life' package.

By adding '.' to sys.path before the import attempt, the script can now locate the package when run from the repository root directory.