### PR TITLE
Fix: Resolve ImportError in streamlit_app.py

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3,10 +3,13 @@ import argparse # Using argparse to create a Namespace object
 import logging
 import pandas as pd # Needed for displaying debug data
 import sys
+import os # Import the os module
 
 # --- Import Simulation Function ---
-# Add the repository root to the Python path
-sys.path.insert(0, '.')
+# Add the directory containing this script to the Python path
+script_dir = os.path.dirname(os.path.abspath(__file__))
+if script_dir not in sys.path:
+    sys.path.insert(0, script_dir)
 # Assuming the script is run from the repo root
 try:
     from financial_life.simulate_main import run_simulation_and_get_results


### PR DESCRIPTION
The Streamlit app was failing to import `run_simulation_and_get_results` from `financial_life.simulate_main` due to an unreliable Python path modification.

The original code used `sys.path.insert(0, '.')`, which assumes the script is always run from the repository root. This can fail depending on the execution environment or how Streamlit is launched.

This commit modifies `streamlit_app.py` to use `os.path.dirname(os.path.abspath(__file__))` to determine the script's directory and adds this absolute path to `sys.path`. This ensures the `financial_life` package can be reliably located and imported regardless of the current working directory.