### PR TITLE
Fix: Use relative import for simulate_funs in simulate_main

### DIFF
--- a/financial_life/simulate_main.py
+++ b/financial_life/simulate_main.py
@@ -15,7 +15,7 @@ from google.cloud import aiplatform, storage
 import numpy_financial as npf
 
 # Import the simulation function
-from simulate_funs import simulate_a_life
+from .simulate_funs import simulate_a_life
 
 
 # --- Refactored Simulation Logic ---


### PR DESCRIPTION
Changed the import statement in `financial_life/simulate_main.py` from `from simulate_funs import simulate_a_life`
to
`from .simulate_funs import simulate_a_life`.

This resolves a `ModuleNotFoundError` that occurred when `simulate_main.py` was executed indirectly (e.g., via `streamlit_app.py` located in the parent directory). Using a relative import ensures the module can be found correctly within the `financial_life` package regardless of the script's entry point.